### PR TITLE
New (imo improved) artist parsing

### DIFF
--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ class BlotterTrax:
                 continue
             
             #get artist for most future use
-            prioArtist = self._get_prioritized_artist(artist_name)
+            prio_artist = self._get_prioritized_artist(artist_name)
             
             # Check Youtube.
             youtube_service = self.youtube.get_service_result(submission.url)
@@ -78,7 +78,7 @@ class BlotterTrax:
 
             # Check Last.FM
             try:
-                last_fm_service = self.last_fm.get_service_result(prioArtist)
+                last_fm_service = self.last_fm.get_service_result(prio_artist)
                 if last_fm_service.exceeds_threshold is True:
                     self._perform_exceeds_threshold_mod_action(submission, last_fm_service)
                     self.database.save_submission(submission)
@@ -90,7 +90,7 @@ class BlotterTrax:
             # Yeey this post probably isn't breaking the rules 🌈
             try:
                 if self.config.SEND_ARTIST_REPLY is True:
-                    self._reply_with_sticky_post(submission, self.last_fm.get_artist_reply(prioArtist))
+                    self._reply_with_sticky_post(submission, self.last_fm.get_artist_reply(prio_artist))
                 # Made it all the way.  Save submission record.
                 self.database.save_submission(submission)
             except (pylast.WSError, LookupError):
@@ -115,67 +115,66 @@ class BlotterTrax:
     def _reply_with_sticky_post(self, submission, reply_text):
         comment = submission.reply(reply_text)
         comment.mod.distinguish("yes", sticky=True)
-    
-    def _get_prioritized_artist(artistList):
-        if artistList[1] is None:
-            return artistList[0]
+
+    @staticmethod
+    def _get_prioritized_artist(artist_list):
+        if artist_list[1] is None:
+            return artist_list[0]
         
-        return artistList[1]
+        return artist_list[1]
     
     @staticmethod
     def _get_artist_name_from_submission_title(post_title):
-
         #get main artist
-        dashChar = ["-","—"]
-        doubleDash = False
+        dash_char = ['-', '—']
+        double_dash = False
         artist = None
-        for x in dashChar:
-            if((x+x) in post_title):
-                artist = post_title.split(x+x)[0].strip()
-                doubleDash = True
+        for dash in dash_char:
+            if (dash + dash) in post_title:
+                artist = post_title.split(dash + dash)[0].strip()
+                double_dash = True
                 break
         
-        if(doubleDash is False):
-            for x in dashChar:
-                if(x in post_title):
-                    artist = post_title.split(x)[0].strip()
+        if double_dash is False:
+            for dash in dash_char:
+                if dash in post_title:
+                    artist = post_title.split(dash)[0].strip()
                     break
         
         
         #get feature artist if exists
-        featureList = ["feat.", "ft.", "feature", "featuring"]
-        lowerTitle = post_title.lower()
-        featureArtist = None
+        feature_list = ["feat.", "ft.", "feature", "featuring"]
+        lower_title = post_title.lower()
+        feature_artist = None
         
-        for x in featureList:
-            if x in lowerTitle:
-                featIndex = lowerTitle.index(x)
+        for feature in feature_list:
+            if feature in lower_title:
+                feat_index = lower_title.index(x)
                 
                 #remove featuring from artist if exists
-                if(len(artist) > featIndex):
-                    artist = artist[:featIndex].strip()
+                if len(artist) > feat_index:
+                    artist = artist[:feat_index].strip()
                 
-                featIndex += len(x)
+                feat_index += len(x)
                 
                 #isolate featuring artist
-                featureArtist = post_title[featIndex:].strip()
+                feature_artist = post_title[featIndex:].strip()
                 break
         
         #further process if found
-        if featureArtist is not None:
-            typicalEndChar = [" -", ")", "[", " —"]
-            for x in typicalEndChar:
-                if x in featureArtist:
-                    featureArtist = featureArtist.split(x)[0]
+        if feature_artist is not None:
+            for end_char in [" -", ")", "[", " —"]:
+                if end_char in feature_artist:
+                    feature_artist = feature_artist.split(x)[0]
         
-        if featureArtist is not None:
-            featureArtist = featureArtist.strip()
+        if feature_artist is not None:
+            feature_artist = feature_artist.strip()
         
-        returnList = [artist, featureArtist]
+        return_list = [artist, feature_artist]
         
-        #if returnlist[0] is none there is no way to trust whatever is in [1] anyway as the post title is a mess.
-        if returnList[0] is not None:
-            return returnList
+        #if return_list[0] is none there is no way to trust whatever is in [1] anyway as the post title is a mess.
+        if return_list[0] is not None:
+            return return_list
         
         raise LookupError
 

--- a/main.py
+++ b/main.py
@@ -143,7 +143,7 @@ class BlotterTrax:
         
         
         #get feature artist if exists
-        feature_list = ["feat.", "ft.", "feature", "featuring"]
+        feature_list = ['feat.', 'ft.', 'feature', 'featuring']
         lower_title = post_title.lower()
         feature_artist = None
         
@@ -163,7 +163,7 @@ class BlotterTrax:
         
         #further process if found
         if feature_artist is not None:
-            for end_char in [" -", ")", "[", " —"]:
+            for end_char in [' -', ')', '[', ' —']:
                 if end_char in feature_artist:
                     feature_artist = feature_artist.split(x)[0]
         

--- a/main.py
+++ b/main.py
@@ -143,11 +143,10 @@ class BlotterTrax:
         
         
         #get feature artist if exists
-        feature_list = ['feat.', 'ft.', 'feature', 'featuring']
         lower_title = post_title.lower()
         feature_artist = None
         
-        for feature in feature_list:
+        for feature in ['feat.', 'ft.', 'feature', 'featuring']:
             if feature in lower_title:
                 feat_index = lower_title.index(x)
                 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 from unittest import TestCase
 
-from main import BlotterTrax
+from title_parser import TitleParser
 
 
 class TestBlotterTrax(TestCase):
@@ -18,6 +18,7 @@ class TestBlotterTrax(TestCase):
             ("upsammy - Another Place - Nous'klaer 011", 'upsammy'),
         ]
         for submission_title, artist in submissions:
-            title = BlotterTrax._get_artist_name_from_submission_title(submission_title)
+            title = TitleParser._get_artist_name_from_submission_title(submission_title)
+            prio_artist = TitleParser._get_prioritized_artist(title)
 
-            self.assertEqual(artist, title)
+            self.assertEqual(artist, prio_artist)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,18 +7,20 @@ class TestBlotterTrax(TestCase):
 
     def test_extract_artist_post_title(self):
         submissions = [
-            ('B12 - Infinite Lites (Original Mix) ', 'B12'),
-            ('Floating Points - Last Bloom ', 'Floating Points'),
-            ('Empty Spaces -- Một Cuộc Sống Khác [Vietnamese/Alternative] (2019) ', 'Empty Spaces'),
-            ('007Bonez & Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez'),
-            ('007Bonez featuring Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez'),
-            ('007Bonez feat Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez'),
-            ('007Bonez feat. Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez'),
-            ('Teen Suicide — Haunt Me x3 [indie rock] (2014)', 'Teen Suicide'),
-            ("upsammy - Another Place - Nous'klaer 011", 'upsammy'),
+            ('B12 - Infinite Lites (Original Mix) ', 'B12', None),
+            ('Floating Points - Last Bloom ', 'Floating Points', None),
+            ('Empty Spaces -- Một Cuộc Sống Khác [Vietnamese/Alternative] (2019) ', 'Empty Spaces', None),
+            ('007Bonez & Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez', 'Adro'),
+            ('007Bonez featuring Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez', 'Adro'),
+            ('007Bonez feat Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez feat Adro', None),
+            ('007Bonez feat. Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez', 'Adro'),
+            ('Teen Suicide — Haunt Me x3 [indie rock] (2014)', 'Teen Suicide', None),
+            ("upsammy - Another Place - Nous'klaer 011", 'upsammy', None),
+            ('ガールズロックバンド革命 - CHANGE', 'ガールズロックバンド革命', None),
+            ('Blume - popo -- 溺レル', 'Blume - popo', None)
         ]
-        for submission_title, artist in submissions:
+        for submission_title, artist, featuring_artist in submissions:
             title = TitleParser._get_artist_name_from_submission_title(submission_title)
-            prio_artist = TitleParser._get_prioritized_artist(title)
 
-            self.assertEqual(artist, prio_artist)
+            self.assertEqual(artist, title[0])
+            self.assertEqual(featuring_artist, title[1])

--- a/title_parser.py
+++ b/title_parser.py
@@ -34,23 +34,23 @@ class TitleParser:
 
         for feature in ['feat.', 'ft.', 'feature', 'featuring', '&']:
             if feature in lower_title:
-                feat_index = lower_title.index(x)
+                feat_index = lower_title.index(feature)
 
                 # remove featuring from artist if exists
                 if len(artist) > feat_index:
                     artist = artist[:feat_index].strip()
 
-                feat_index += len(x)
+                feat_index += len(feature)
 
                 # isolate featuring artist
-                feature_artist = post_title[featIndex:].strip()
+                feature_artist = post_title[feat_index:].strip()
                 break
 
         # further process if found
         if feature_artist is not None:
             for end_char in [' -', ')', '[', ' —']:
                 if end_char in feature_artist:
-                    feature_artist = feature_artist.split(x)[0]
+                    feature_artist = feature_artist.split(end_char)[0]
 
         if feature_artist is not None:
             feature_artist = feature_artist.strip()

--- a/title_parser.py
+++ b/title_parser.py
@@ -1,0 +1,64 @@
+class TitleParser:
+
+    def __init__(self):
+        print("parser loaded") #idk the IDE told me I need an init thing ¯\_(ツ)_/¯
+
+    @staticmethod
+    def _get_prioritized_artist(artist_list):
+        if artist_list[1] is None:
+            return artist_list[0]
+
+        return artist_list[1]
+
+    @staticmethod
+    def _get_artist_name_from_submission_title(post_title):
+        # get main artist
+        dash_char = ['-', '—']
+        double_dash = False
+        artist = None
+        for dash in dash_char:
+            if (dash + dash) in post_title:
+                artist = post_title.split(dash + dash)[0].strip()
+                double_dash = True
+                break
+
+        if double_dash is False:
+            for dash in dash_char:
+                if dash in post_title:
+                    artist = post_title.split(dash)[0].strip()
+                    break
+
+        # get feature artist if exists
+        lower_title = post_title.lower()
+        feature_artist = None
+
+        for feature in ['feat.', 'ft.', 'feature', 'featuring']:
+            if feature in lower_title:
+                feat_index = lower_title.index(x)
+
+                # remove featuring from artist if exists
+                if len(artist) > feat_index:
+                    artist = artist[:feat_index].strip()
+
+                feat_index += len(x)
+
+                # isolate featuring artist
+                feature_artist = post_title[featIndex:].strip()
+                break
+
+        # further process if found
+        if feature_artist is not None:
+            for end_char in [' -', ')', '[', ' —']:
+                if end_char in feature_artist:
+                    feature_artist = feature_artist.split(x)[0]
+
+        if feature_artist is not None:
+            feature_artist = feature_artist.strip()
+
+        return_list = [artist, feature_artist]
+
+        # if return_list[0] is none there is no way to trust whatever is in [1] anyway as the post title is a mess.
+        if return_list[0] is not None:
+            return return_list
+
+        raise LookupError

--- a/title_parser.py
+++ b/title_parser.py
@@ -32,7 +32,7 @@ class TitleParser:
         lower_title = post_title.lower()
         feature_artist = None
 
-        for feature in ['feat.', 'ft.', 'feature', 'featuring']:
+        for feature in ['feat.', 'ft.', 'feature', 'featuring', '&']:
             if feature in lower_title:
                 feat_index = lower_title.index(x)
 


### PR DESCRIPTION
Main functionality is removing regex and relying on native functions. Beyond that, is a fair bit more rigorous (for instance, if there was an artist with a dash in their name, say blume - popo, "blume - popo -- title" would be interpreted as blume, not blume - popo. There are a couple more improvements as well, though I mightve missed some functionality due to my inexperience with regex). Does take up more space though, though it might be faster simply because regex. Didn't benchmark though.

The changes to the return mechanism is necessary for the functioning of the song parsing I commited in #14 (though it won't work without some changes, so this should be merged before #14, whether in its current form or with the regex changes reverted, but return mechanism preserved)