### PR TITLE
Remove exception for playlist posts

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,10 +48,6 @@ class BlotterTrax:
                 self.database.save_submission(submission)
                 # We currently don't do anything further with self posts.  Move to the next post.
                 continue
-            if "playlist" in submission.title.lower():
-                # We currently don't do anything with Playlist posts.  Move to the next post.
-                self.database.save_submission(submission)
-                continue
 
             try:
                 artist_name = TitleParser.get_artist_name_from_submission_title(submission.title)


### PR DESCRIPTION
Reflects the recent rule change on the sub

EDIT: There are a couple extra steps that can be taken to fully stop playlist posts, but having self posts removed even when containing playlist in title is a good start