### PR TITLE
Log error submissions

### DIFF
--- a/blottertrax/database.py
+++ b/blottertrax/database.py
@@ -25,7 +25,7 @@ class Database:
 
         if parsed is not None:
             self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, parsed.url, parsed.track_title, parsed.artist, error])
-        else
+        else:
             self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.title, "", error])
         self.sql.commit()
 

--- a/blottertrax/database.py
+++ b/blottertrax/database.py
@@ -24,9 +24,9 @@ class Database:
             self.save_submission(raw) # Save it so we will skip it next time we parse.
 
         if parsed is not None:
-            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, raw.permalink, parsed.url, parsed.track_title, parsed.artist, error])
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, parsed.url, parsed.track_title, parsed.artist, error])
         else:
-            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.url, raw.title, "", error])
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.url, raw.title, "", error])
         self.sql.commit()
 
     def known_submission(self, submission) -> bool:

--- a/blottertrax/database.py
+++ b/blottertrax/database.py
@@ -12,9 +12,21 @@ class Database:
 
         self.cursor.execute('CREATE TABLE IF NOT EXISTS submissions(id TEXT)')
         self.cursor.execute('CREATE INDEX IF NOT EXISTS postindex on submissions(id)')
+        self.cursor.execute('CREATE TABLE IF NOT EXISTS errorCausingSubmissions(id TEXT NOT NULL, url TEXT, title TEXT, artist TEXT, error TEXT)')
 
     def save_submission(self, submission):
         self.cursor.execute('INSERT INTO submissions VALUES(?)', [submission.id])
+        self.sql.commit()
+
+    def log_error_causing_submission(self, parsed, raw, error, save_submission = False):
+
+        if save_submission is True:
+            self.save_submission(raw) # Save it so we will skip it next time we parse.
+
+        if parsed is not None:
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, parsed.url, parsed.track_title, parsed.artist, error])
+        else
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.title, "", error])
         self.sql.commit()
 
     def known_submission(self, submission) -> bool:

--- a/blottertrax/database.py
+++ b/blottertrax/database.py
@@ -12,7 +12,7 @@ class Database:
 
         self.cursor.execute('CREATE TABLE IF NOT EXISTS submissions(id TEXT)')
         self.cursor.execute('CREATE INDEX IF NOT EXISTS postindex on submissions(id)')
-        self.cursor.execute('CREATE TABLE IF NOT EXISTS errorCausingSubmissions(id TEXT NOT NULL, url TEXT, title TEXT, artist TEXT, error TEXT)')
+        self.cursor.execute('CREATE TABLE IF NOT EXISTS errorCausingSubmissions(id TEXT NOT NULL, permalink TEXT, url TEXT, title TEXT, artist TEXT, error TEXT)')
 
     def save_submission(self, submission):
         self.cursor.execute('INSERT INTO submissions VALUES(?)', [submission.id])
@@ -24,9 +24,9 @@ class Database:
             self.save_submission(raw) # Save it so we will skip it next time we parse.
 
         if parsed is not None:
-            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, parsed.url, parsed.track_title, parsed.artist, error])
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, raw.permalink, parsed.url, parsed.track_title, parsed.artist, error])
         else:
-            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.title, "", error])
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.url, raw.title, "", error])
         self.sql.commit()
 
     def known_submission(self, submission) -> bool:

--- a/blottertrax/database.py
+++ b/blottertrax/database.py
@@ -12,7 +12,7 @@ class Database:
 
         self.cursor.execute('CREATE TABLE IF NOT EXISTS submissions(id TEXT)')
         self.cursor.execute('CREATE INDEX IF NOT EXISTS postindex on submissions(id)')
-        self.cursor.execute('CREATE TABLE IF NOT EXISTS errorCausingSubmissions(id TEXT NOT NULL, permalink TEXT, url TEXT, title TEXT, artist TEXT, error TEXT)')
+        self.cursor.execute('CREATE TABLE IF NOT EXISTS errorCausingSubmissions(id TEXT NOT NULL, permalink TEXT, url TEXT, postTitle TEXT, artist TEXT, songTitle TEXT, error TEXT)')
 
     def save_submission(self, submission):
         self.cursor.execute('INSERT INTO submissions VALUES(?)', [submission.id])
@@ -24,9 +24,9 @@ class Database:
             self.save_submission(raw) # Save it so we will skip it next time we parse.
 
         if parsed is not None:
-            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, parsed.url, parsed.track_title, parsed.artist, error])
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, parsed.url, raw.title, parsed.track_title, parsed.artist, error])
         else:
-            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.url, raw.title, "", error])
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.url, raw.title, "", "", error])
         self.sql.commit()
 
     def known_submission(self, submission) -> bool:

--- a/blottertrax/database.py
+++ b/blottertrax/database.py
@@ -24,7 +24,7 @@ class Database:
             self.save_submission(raw) # Save it so we will skip it next time we parse.
 
         if parsed is not None:
-            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, parsed.url, raw.title, parsed.track_title, parsed.artist, error])
+            self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, parsed.url, raw.title, parsed.artist, parsed.track_title, error])
         else:
             self.cursor.execute('INSERT INTO errorCausingSubmissions VALUES(?, ?, ?, ?, ?, ?, ?)', [raw.id, raw.permalink, raw.url, raw.title, "", "", error])
         self.sql.commit()

--- a/blottertrax/helper/title_parser.py
+++ b/blottertrax/helper/title_parser.py
@@ -23,8 +23,8 @@ class TitleParser:
         if artist is None:
             raise LookupError
 
-        for feature in [' feat. ', ' ft. ', ' feature ', ' featuring ', ' feat ']:
-            if feature not in post_title or artist is None:
+        for feature in [' feat. ', ' feat ', ' ft. ', ' feature ', ' featuring ', ' feat ', ' & ']:
+            if feature not in post_title:
                 continue
 
             feat_index = post_title.index(feature)
@@ -49,8 +49,8 @@ class TitleParser:
             raise LookupError
 
         # Remove everything between () and []
-        song_title = re.sub(r"\(.*\)", "", song_title)
-        song_title = re.sub(r"[.*]", "", song_title)
+        song_title = re.sub(r"\((.*?)\)", "", song_title)
+        song_title = re.sub(r"\[(.*?)\]", "", song_title)
         song_title = song_title.strip()
 
         if artist is not None:

--- a/blottertrax/helper/title_parser.py
+++ b/blottertrax/helper/title_parser.py
@@ -23,7 +23,7 @@ class TitleParser:
         if artist is None:
             raise LookupError
 
-        for feature in [' feat. ', ' feat ', ' ft. ', ' feature ', ' featuring ', ' feat ', ' & ']:
+        for feature in [' feat. ', ' ft. ', ' feature ', ' featuring ', ' feat ', ' & ']:
             if feature not in post_title:
                 continue
 

--- a/blottertrax/helper/title_parser.py
+++ b/blottertrax/helper/title_parser.py
@@ -20,8 +20,11 @@ class TitleParser:
 
                 break
 
-        for feature in [' feat. ', ' ft. ', ' feature ', ' featuring ', ' & ']:
-            if feature not in post_title:
+        if artist is None:
+            raise LookupError
+
+        for feature in [' feat. ', ' ft. ', ' feature ', ' featuring ', ' feat ']:
+            if feature not in post_title or artist is None:
                 continue
 
             feat_index = post_title.index(feature)
@@ -41,6 +44,9 @@ class TitleParser:
                     feature_artist, song_title = split_result
 
                     break
+
+        if song_title is None:
+            raise LookupError
 
         # Remove everything between () and []
         song_title = re.sub(r"\(.*\)", "", song_title)

--- a/main.py
+++ b/main.py
@@ -39,6 +39,8 @@ class BlotterTrax:
 
     def _run(self):
         for submission in self.reddit.subreddit(self.config.SUBREDDIT).stream.submissions():
+            print(submission.title + "-" + submission.permalink)
+
             exceeds_threshold = False
 
             if self.database.known_submission(submission) is True:
@@ -53,7 +55,7 @@ class BlotterTrax:
                 parsed_submission = TitleParser.create_parsed_submission_from_submission(submission)
             except LookupError:
                 # Can't find artist from submission name, skipping
-                self.database.save_submission(submission)
+                self.database.log_error_causing_submission(None, submission, traceback.format_exc(), True)
                 continue
 
             for service in self.services:
@@ -67,6 +69,7 @@ class BlotterTrax:
                         break
                 except Exception:
                     traceback.print_exc(file=sys.stdout)
+                    self.database.log_error_causing_submission(parsed_submission, submission, traceback.format_exc())
                     # Go ahead and continue execution
                     # Don't want to fail completely just because one service failed.
                     pass

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ class BlotterTrax:
 
     def _run(self):
         for submission in self.reddit.subreddit(self.config.SUBREDDIT).stream.submissions():
-            print(submission.title + "-" + submission.permalink)
+            print(submission.title + " - http://reddit.com" + submission.permalink)
 
             exceeds_threshold = False
 

--- a/tests/test_artist_parser.py
+++ b/tests/test_artist_parser.py
@@ -19,15 +19,16 @@ class TestBlotterTrax(TestCase):
              'Một Cuộc Sống Khác'),
             ('007Bonez & Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez', 'Adro', 'Motion'),
             ('007Bonez featuring Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez', 'Adro', 'Motion'),
-            ('007Bonez feat Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez feat Adro', None, 'Motion'),
+            ('007Bonez feat Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez', 'Adro', 'Motion'),
             ('007Bonez feat. Adro - Motion [Hip-Hop / Rap] (2019)', '007Bonez', 'Adro', 'Motion'),
             ('Teen Suicide — Haunt Me x3 [indie rock] (2014)', 'Teen Suicide', None, 'Haunt Me x3'),
-            ("upsammy - Another Place - Nous'klaer 011", 'upsammy', None, "Another Place - Nous'klaer 011"),
+            ("upsammy - Another Place - Nous'klaer 011", 'upsammy', None, "Another Place"), # should Nous'klaer 011 actually be included for title?
             ('ガールズロックバンド革命 - CHANGE', 'ガールズロックバンド革命', None, 'CHANGE'),
         ]
+
         for submission_title, artist, featuring_artist, song_title in submissions:
             title = TitleParser.create_parsed_submission_from_submission(MockedSubmission(submission_title))
 
             self.assertEqual(artist, title.artist)
             self.assertEqual(featuring_artist, title.featuring_artist)
-            # self.assertEqual(song_title, title.track_title)
+            self.assertEqual(song_title, title.track_title)


### PR DESCRIPTION
Closes #17.

Also relates to #43. (Think it will technically close it but it isn't exactly full featured either).

Basically anytime we fail a lookup/artist parsing/etc. we log it into the "errorCausingSubmissions" table.  This table gives us the ID of the submission, a link to the submission, the URL that was linked, the title/artist if the song parsing succeeded and a full stack trace of where the error occurred.

See: https://i.imgur.com/hlEsZr4.jpg for quick example.

Got tired of trying to search docker logs to understand what was happening.