### PR TITLE
Skip self promotion checks if names too short.

### DIFF
--- a/blottertrax/helper/self_promo_detector.py
+++ b/blottertrax/helper/self_promo_detector.py
@@ -11,6 +11,11 @@ class SelfPromoDetector:
         poster_name = raw_submission.author.name.lower().replace("_", "").replace("-", "")
         artist_name = parsed_submission.artist.lower().replace(" ", "").replace("_", "").replace("-", "")
 
+        # If the username of the poster or the artist is less than 4 characters, skip self promo checks.
+        # https://github.com/martijnboers/BlotterTrax/issues/26#issuecomment-600792600
+        if len(poster_name) < 4 or len(artist_name) < 4:
+            return False
+
         # Super simple check.  Ensure the posters name does not appear in the name of the artist or the featured artist.
         # TODO: Add additional checks. https://github.com/martijnboers/BlotterTrax/issues/26
         if artist_name in poster_name:

--- a/tests/test_self_promo.py
+++ b/tests/test_self_promo.py
@@ -48,3 +48,8 @@ class TestSelfPromo(TestCase):
         parsed = ParsedSubmission(True, 'url', 'te_str-edd-itor 01rocks')
         sub = MockedSubmission("TestRedditor")
         self.assertTrue(SelfPromoDetector.is_self_promo(parsed, sub))
+
+    def test_it_should_fail_on_short_user_names(self):
+        parsed = ParsedSubmission(True, 'url', 'Test_Red_Ditor')
+        sub = MockedSubmission("-------___e____") # Evals to just "e" inside detector
+        self.assertFalse(SelfPromoDetector.is_self_promo(parsed, sub))


### PR DESCRIPTION
https://github.com/martijnboers/BlotterTrax/issues/26#issuecomment-600792600

We want to skip self promotion test if the username or artist name are super short as it can cause false positives.