### PR TITLE
Not always service_name available

### DIFF
--- a/blottertrax/applications/submissions.py
+++ b/blottertrax/applications/submissions.py
@@ -87,7 +87,7 @@ class Submissions:
 
             except Exception:
                 # Go ahead and continue execution, don't want to fail completely just because one service failed.
-                self.logger.exception(f"Getting {service.service_name} failed")
+                self.logger.exception(f"Getting {type(service).__name__} failed")
                 self.database.log_error_causing_submission(parsed_submission, submission, traceback.format_exc())
 
         # TODO: Enable this when new rules roll out.


### PR DESCRIPTION
```
2020-11-11 01:08:19,704 :INFO: Handling Prod. Amerigo Gazaway - Sex Machine Gun Funk [hip hop/soul] (2019) - http://reddit.com/r/listentothis/comments/jry383/prod_amerigo_gazaway_sex_machine_gun_funk_hip/
2020-11-11 01:08:20,804 :ERROR: SubmissionDaemon threw exception
Traceback (most recent call last):
  File "/usr/src/app/blottertrax/applications/submissions.py", line 79, in _do_service_checks
    result = service.get_service_result(parsed_submission)
  File "/usr/src/app/blottertrax/services/lastfm.py", line 30, in get_service_result
    listeners = artist.get_listener_count()
  File "/usr/local/lib/python3.7/site-packages/pylast/__init__.py", line 1748, in get_listener_count
    _extract(self._request(self.ws_prefix + ".getInfo", True), "listeners")
  File "/usr/local/lib/python3.7/site-packages/pylast/__init__.py", line 1123, in _request
    return _Request(self.network, method_name, params).execute(cacheable)
  File "/usr/local/lib/python3.7/site-packages/pylast/__init__.py", line 956, in execute
    response = self._download_response()
  File "/usr/local/lib/python3.7/site-packages/pylast/__init__.py", line 945, in _download_response
    self._check_response_for_errors(response_text)
  File "/usr/local/lib/python3.7/site-packages/pylast/__init__.py", line 975, in _check_response_for_errors
    raise WSError(self.network, status, details)
pylast.WSError: The artist you supplied could not be found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/src/app/blottertrax/daemons/submissions_daemon.py", line 18, in start
    Submissions(lock).run()
  File "/usr/src/app/blottertrax/applications/submissions.py", line 54, in run
    exceeds_threshold = self._do_service_checks(parsed_submission, submission)
  File "/usr/src/app/blottertrax/applications/submissions.py", line 90, in _do_service_checks
    self.logger.exception(f"Getting {service.service_name} failed")
AttributeError: 'LastFM' object has no attribute 'service_name'
```