### PR TITLE
Fixes modmail daemon restarting constantly.

### DIFF
--- a/blottertrax/applications/modmail.py
+++ b/blottertrax/applications/modmail.py
@@ -28,7 +28,7 @@ class ModMail:
     def run(self):
         for message in self.reddit.subreddit(self.config.SUBREDDIT).mod.stream.modmail_conversations(state="new"):
             if self.database.known_mod_mail(message) is True:
-                return
+                continue
 
             try:
                 current_time_utc = datetime.datetime.utcnow()


### PR DESCRIPTION
The modmail daemon was restarting constantly.  Turns out we were *returning* when we came across a known modmail rather than using the continue keyword as desired.

Output was:

```
2020-11-13 19:47:51,064 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:51,703 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:52,379 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:53,006 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:53,641 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:54,303 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:54,966 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:55,575 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:56,259 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:47:57,032 :INFO: Starting ModMailDaemon daemon
```

And now it lives properly and answers messages as expected.

```
2020-11-13 19:54:53,575 :INFO: Starting ModMailDaemon daemon
2020-11-13 19:54:54,304 :INFO: Handling message ifi61
2020-11-13 19:54:54,589 :INFO: Notifying  <redacted>, that their account is too new
```