### PR TITLE
Change our Docker base image to the alpine version.  

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+venv/
+tests/
+.idea/
+.github/
+conf/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.6-buster
+FROM python:3.7-alpine3.12
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
This is significantly smaller at around 150Mb built instead of 1Gb.